### PR TITLE
add frs client w/ toggle b/w local and remote

### DIFF
--- a/.env.frs
+++ b/.env.frs
@@ -1,0 +1,2 @@
+# Use environment variable to switch between connecting to FRS or Tinylicious
+REACT_APP_USE_FRS=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,163 +1486,154 @@
       }
     },
     "@fluid-experimental/fluid-framework": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-framework/-/fluid-framework-0.41.0.tgz",
-      "integrity": "sha512-kkRcTAJ+cgtDamYSU/lMf3bzXU3iQT/5toUv4sMcJlCldkrJ1taypHr7F2uxuS1QS/7QXi/kGlxeMSwvH8d6WQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-framework/-/fluid-framework-0.43.0.tgz",
+      "integrity": "sha512-Vzk5YNYft+r6BQobZljxUYHK8Uuq+swAkZMhJPw8VluvOCj59qnLozJdflgM5+a1kXw/KDmv1Uo+9x6HEWP1vw==",
       "requires": {
-        "@fluidframework/aqueduct": "^0.41.0",
-        "@fluidframework/map": "^0.41.0",
-        "@fluidframework/merge-tree": "^0.41.0",
-        "@fluidframework/sequence": "^0.41.0"
-      }
-    },
-    "@fluid-experimental/fluid-static": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-static/-/fluid-static-0.41.0.tgz",
-      "integrity": "sha512-ilsax15AELRWdD0TbkTxHsPh9Ecj+4hqugCaCPix22+tn6QZQbZ27Ei0r/bjAWpWTnNA3J2HvsV6x1wimly/Jg==",
-      "requires": {
-        "@fluid-experimental/get-container": "^0.41.0",
-        "@fluidframework/aqueduct": "^0.41.0",
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-loader": "^0.41.0",
-        "@fluidframework/container-runtime-definitions": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/request-handler": "^0.41.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0"
-      }
-    },
-    "@fluid-experimental/get-container": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/get-container/-/get-container-0.41.0.tgz",
-      "integrity": "sha512-e68jHPNLTh27E2QbD5JLW2/G836fGRumJqI3DyG6V6LSYa9kU3VPovMVPjcpDt0fkPC6pcSL/HsBAQJ+BBqlLQ==",
-      "requires": {
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-loader": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/local-driver": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/routerlicious-driver": "^0.41.0",
-        "@fluidframework/server-local-server": "^0.1026.0",
-        "@fluidframework/test-runtime-utils": "^0.41.0",
-        "@fluidframework/tinylicious-driver": "^0.41.0",
-        "jsonwebtoken": "^8.4.0"
-      }
-    },
-    "@fluid-experimental/tinylicious-client": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluid-experimental/tinylicious-client/-/tinylicious-client-0.41.0.tgz",
-      "integrity": "sha512-SsUmG360LS8qm69dSnoW1qPd4iyKNQJN1JYic2PZuonnwvM6ayBYjnoD7DozcJn3nb2cnCojkWLvtwM60jLleA==",
-      "requires": {
-        "@fluid-experimental/fluid-static": "^0.41.0",
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-loader": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/routerlicious-driver": "^0.41.0",
-        "@fluidframework/tinylicious-driver": "^0.41.0"
-      }
-    },
-    "@fluidframework/agent-scheduler": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/agent-scheduler/-/agent-scheduler-0.41.0.tgz",
-      "integrity": "sha512-g68bTzOP5Znzn1v0DL47FFnuN7Yx+dXDdU9cSunmpEnC3Gx/R8JJxeD9YNer35kR0b3CQ7sLqOaITK7obfnysg==",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore": "^0.41.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/map": "^0.41.0",
-        "@fluidframework/register-collection": "^0.41.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "assert": "^2.0.0",
-        "debug": "^4.1.1",
-        "uuid": "^8.3.1"
+        "@fluid-experimental/fluid-static": "^0.43.0",
+        "@fluidframework/aqueduct": "^0.43.0",
+        "@fluidframework/map": "^0.43.0",
+        "@fluidframework/merge-tree": "^0.43.0",
+        "@fluidframework/sequence": "^0.43.0"
       },
       "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
+        "@fluid-experimental/fluid-static": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluid-experimental/fluid-static/-/fluid-static-0.43.0.tgz",
+          "integrity": "sha512-qWDRcw+eSVWydbb7micixUcqEJHA3sp0DLsCxj4QGk/4smeMIqMTIlR8P7Z0k2c36+ccHaPg/d5Y8I8EkmNTXQ==",
           "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
+            "@fluidframework/aqueduct": "^0.43.0",
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^0.31.0",
+            "@fluidframework/container-definitions": "^0.39.5",
+            "@fluidframework/container-loader": "^0.43.0",
+            "@fluidframework/container-runtime-definitions": "^0.43.0",
+            "@fluidframework/core-interfaces": "^0.39.5",
+            "@fluidframework/datastore-definitions": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1024.0",
+            "@fluidframework/request-handler": "^0.43.0",
+            "@fluidframework/runtime-definitions": "^0.43.0",
+            "@fluidframework/runtime-utils": "^0.43.0"
+          }
+        }
+      }
+    },
+    "@fluid-experimental/frs-client": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluid-experimental/frs-client/-/frs-client-0.43.0.tgz",
+      "integrity": "sha512-H9sn+p1HtFCpWxc2lwuZgA2ajNsYlviHWTxNRebpIrWkMq2iLy3MSdcTzFFYyKDD+33PfzUvnTnpdSKhXcwCHg==",
+      "requires": {
+        "@fluid-experimental/fluid-framework": "^0.43.0",
+        "@fluidframework/common-definitions": "^0.20.1",
+        "@fluidframework/container-loader": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/driver-definitions": "^0.39.0",
+        "@fluidframework/protocol-definitions": "^0.1024.0",
+        "@fluidframework/routerlicious-driver": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/server-services-client": "^0.1027.0",
+        "@fluidframework/test-runtime-utils": "^0.43.0",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "@fluidframework/driver-base": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.43.0.tgz",
+          "integrity": "sha512-7ayZPYoir4/T5mpYPgMxjeIqlzhzJmYT9ksiu9I1jdw68tuEWJ6s5vqyZKi8eci5DLmwHki1QDpcwxWxdscm9g==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^0.31.0",
+            "@fluidframework/driver-definitions": "^0.39.0",
+            "@fluidframework/driver-utils": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1024.0",
+            "debug": "^4.1.1"
           }
         },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+        "@fluidframework/routerlicious-driver": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.43.0.tgz",
+          "integrity": "sha512-9Fd/+yC4IvQlFn8R4+T6kQBql1U1DTWj74CiEahaP+kP9t7ZbCkGRPn9ltW7VYelqNVMQ1xvOAHCU9WQSUdXbQ==",
           "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^0.31.0",
+            "@fluidframework/driver-base": "^0.43.0",
+            "@fluidframework/driver-definitions": "^0.39.0",
+            "@fluidframework/driver-utils": "^0.43.0",
+            "@fluidframework/gitresources": "^0.1027.0",
+            "@fluidframework/protocol-base": "^0.1027.0",
+            "@fluidframework/protocol-definitions": "^0.1024.0",
+            "@fluidframework/server-services-client": "^0.1027.0",
+            "@fluidframework/telemetry-utils": "^0.43.0",
+            "axios": "^0.21.1",
+            "debug": "^4.1.1",
+            "json-stringify-safe": "5.0.1",
+            "socket.io-client": "^2.1.1",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/server-services-client": {
+          "version": "0.1027.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1027.0.tgz",
+          "integrity": "sha512-FQcC3TPhfs/GHtfW/0aqGD5rehwhgCmZcmAWDi+QkKatWzV/Z/SD0uyA7Bk9qRE5jgNNP3ny5XaZ4jETJJ2Zvg==",
+          "requires": {
+            "@fluidframework/common-utils": "^0.31.0",
+            "@fluidframework/gitresources": "^0.1027.0",
+            "@fluidframework/protocol-base": "^0.1027.0",
+            "@fluidframework/protocol-definitions": "^0.1024.0",
+            "@types/node": "^12.19.0",
+            "axios": "^0.21.1",
+            "debug": "^4.1.1",
+            "jsrsasign": "^10.2.0",
+            "jwt-decode": "^3.0.0",
+            "sillyname": "0.1.0",
+            "uuid": "^8.3.1"
+          }
+        },
+        "@fluidframework/test-runtime-utils": {
+          "version": "0.43.0",
+          "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.43.0.tgz",
+          "integrity": "sha512-haMpQxrEt0/k5rEA+jZ5z29Y6oHzY4anAOZIoNQbF+pM8/3O76+vTuAKFoc5vyjWtS5BnT2QwBfxpkRW6B8jVA==",
+          "requires": {
+            "@fluidframework/common-definitions": "^0.20.1",
+            "@fluidframework/common-utils": "^0.31.0",
+            "@fluidframework/container-definitions": "^0.39.5",
+            "@fluidframework/core-interfaces": "^0.39.5",
+            "@fluidframework/datastore-definitions": "^0.43.0",
+            "@fluidframework/driver-definitions": "^0.39.0",
+            "@fluidframework/driver-utils": "^0.43.0",
+            "@fluidframework/protocol-definitions": "^0.1024.0",
+            "@fluidframework/routerlicious-driver": "^0.43.0",
+            "@fluidframework/runtime-definitions": "^0.43.0",
+            "@fluidframework/runtime-utils": "^0.43.0",
+            "@fluidframework/telemetry-utils": "^0.43.0",
+            "axios": "^0.21.1",
+            "jsrsasign": "^10.2.0",
+            "uuid": "^8.3.1"
           }
         }
       }
     },
     "@fluidframework/aqueduct": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.41.0.tgz",
-      "integrity": "sha512-PxwJPFvNRo7Cn7elYmzm8jsslU40v53ydmuopzn1OSitj+zF3Ij7QjP+g1vhyqxf26BtmPCZ5I2muHCnGu4/BQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/aqueduct/-/aqueduct-0.43.0.tgz",
+      "integrity": "sha512-awQrAd2eKDi6TX6XettHbVL11FLorol8MY0hjMg+JSMPg79K9Bxt4dia2gplPh12feIP381OsS1CuKCLmY9MqQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-loader": "^0.41.0",
-        "@fluidframework/container-runtime": "^0.41.0",
-        "@fluidframework/container-runtime-definitions": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore": "^0.41.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/map": "^0.41.0",
-        "@fluidframework/request-handler": "^0.41.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/synthesize": "^0.41.0",
-        "@fluidframework/view-interfaces": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/container-loader": "^0.43.0",
+        "@fluidframework/container-runtime": "^0.43.0",
+        "@fluidframework/container-runtime-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore": "^0.43.0",
+        "@fluidframework/datastore-definitions": "^0.43.0",
+        "@fluidframework/map": "^0.43.0",
+        "@fluidframework/request-handler": "^0.43.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/synthesize": "^0.43.0",
+        "@fluidframework/view-interfaces": "^0.43.0",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/common-definitions": {
@@ -1664,495 +1655,218 @@
       }
     },
     "@fluidframework/container-definitions": {
-      "version": "0.39.4",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.4.tgz",
-      "integrity": "sha512-P6w+saefD2Q4U4Bb6MeCp5ohrkN1tUKAOFQxqhfhWzXfhVaT+EmSLpCPtqkoJ218U9eHVhG31f0wgW3znZbKAA==",
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-definitions/-/container-definitions-0.39.6.tgz",
+      "integrity": "sha512-toyJItu+W8IkEGYh5UXZ0CC7V30NCbKBXgBPL2Rwvf31dZ6TA91KM3nmutL/bCXHTHzH4jDkyaLqi2UQMx4UCg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.39.4",
-        "@fluidframework/driver-definitions": "^0.39.4",
+        "@fluidframework/core-interfaces": "^0.39.6",
+        "@fluidframework/driver-definitions": "^0.39.6",
         "@fluidframework/protocol-definitions": "^0.1024.0"
       }
     },
     "@fluidframework/container-loader": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.41.0.tgz",
-      "integrity": "sha512-LWtOkZfEGDSkLeI989Aq8gXyYY+7U16NYxtV+kNSCtaprhzplq8EDIhkYTSdAY8Vc1zIFdYgco2T+OpJyTaWlA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-loader/-/container-loader-0.43.0.tgz",
+      "integrity": "sha512-qU1/vLyAVjmbp431/NqmmEkYxCn24UlhT1hv3kTcncAngjYc29fmKppE4kdQASk/bng9p5gS02Y+tc89zn6BjQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-utils": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/container-utils": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/driver-utils": "^0.43.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "abort-controller": "^3.0.0",
-        "assert": "^2.0.0",
         "debug": "^4.1.1",
         "double-ended-queue": "^2.1.0-0",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/container-runtime": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.41.0.tgz",
-      "integrity": "sha512-fkntMrOheI6wLXINODGxT0h203C5ObL+K4FcfnIE+D8W6ZS+eHiRDb0DOPNFYJZopNifDtmk6bCT/RxB+Jx2MQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime/-/container-runtime-0.43.0.tgz",
+      "integrity": "sha512-vpyjl78WclBWqdw+uiQXQYDmcjNF64SNaW4MVQPuxGNPqx6X2Y67oIi3etw7NHLPF5PaXoVfK20t4V445NjriA==",
       "requires": {
-        "@fluidframework/agent-scheduler": "^0.41.0",
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-runtime-definitions": "^0.41.0",
-        "@fluidframework/container-utils": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/container-runtime-definitions": "^0.43.0",
+        "@fluidframework/container-utils": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore": "^0.43.0",
         "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/garbage-collector": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/driver-utils": "^0.43.0",
+        "@fluidframework/garbage-collector": "^0.43.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "debug": "^4.1.1",
         "double-ended-queue": "^2.1.0-0",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/container-runtime-definitions": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.41.0.tgz",
-      "integrity": "sha512-rtK6B2aoF3KDumubKzUKICHc9A7wbh2TfleuW1cwBb9+JYQqZoVnyhbdImos2QUuNhoLcZwDbI7W/7Ek9QJV1Q==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-runtime-definitions/-/container-runtime-definitions-0.43.0.tgz",
+      "integrity": "sha512-9dxLP2oKZuHpD5bXTLmH+H2q73PrXFQaP2TZUlQpFfR4EYI0vTY8QmLHn4odSfLnk/kDm/Yngqd4ieJpXJ9Wmw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/driver-definitions": "^0.39.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
         "@types/node": "^12.19.0"
       }
     },
     "@fluidframework/container-utils": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.41.0.tgz",
-      "integrity": "sha512-QaUrhgEDfWluLClBzBrhHmQxqq6vsVexwciYR1seeHe66DYw0UqppoKxSEaXM8+LMX5J+fZEnkFBCSPd0xib5w==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/container-utils/-/container-utils-0.43.0.tgz",
+      "integrity": "sha512-dvx0aTj+jcDnQKQVVrkmuO/OoG3a9xtD3lhZDcA3QXxctyrqAoqFlwfzXcLcNTRPEZPu9Z3sepdxTtNYO65pwA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
+        "@fluidframework/container-definitions": "^0.39.5",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
+        "@fluidframework/telemetry-utils": "^0.43.0"
       }
     },
     "@fluidframework/core-interfaces": {
-      "version": "0.39.4",
-      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.4.tgz",
-      "integrity": "sha512-7JkX3kxMx/gZVJFnLl0tvNifHgnbqyKD/M0ckZ5xqiXDR6IvjGMV54Gl1HeaQXoy4C7Guv5ARbb/GujHXI9CZA=="
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/core-interfaces/-/core-interfaces-0.39.6.tgz",
+      "integrity": "sha512-0xjYiRrd71+vS/cXPO8ejPuEfju7TD1NQquA+nWUcB9J5vv5NzdgQAcFAiPSmm/gwpKj4qbuVcN3144GN+qNEg=="
     },
     "@fluidframework/datastore": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.41.0.tgz",
-      "integrity": "sha512-qc5YBgH4x5L8LINwv1YmNt0kGbN9y9sPjUlMvME6HW3K3/cj+jSTQka2As7Zr9fEAE57/JrAEictDEnd98wpRg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore/-/datastore-0.43.0.tgz",
+      "integrity": "sha512-MIRu9Jxu9J5BJQmggVxuMLeKbhrnQewcr1eYALo8lMvSNO/fwxetHjTBiL91sY0sUDaW2AB6BMtQfuFB6nWr9w==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/container-utils": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/container-utils": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore-definitions": "^0.43.0",
         "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/garbage-collector": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/driver-utils": "^0.43.0",
+        "@fluidframework/garbage-collector": "^0.43.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "debug": "^4.1.1",
         "lodash": "^4.17.21",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/datastore-definitions": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.41.0.tgz",
-      "integrity": "sha512-GX/hQz1ihtRyv6Yszx2qli0M9cqGPb7lbAZ159iEXFNDPddXYExVsbOnCrrAjZ2IycwPL0aeLFAnjI4Tm5Bs0w==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/datastore-definitions/-/datastore-definitions-0.43.0.tgz",
+      "integrity": "sha512-ShAg0at75qJV2z5d5D4Qi7KHUVM4u2LP2Mp691puL5KVMgQFn3dyGX0n5JO2Xd6ciIIgii1oey57rS/KKN/nbQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
         "@types/node": "^12.19.0"
       }
     },
-    "@fluidframework/driver-base": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-base/-/driver-base-0.41.0.tgz",
-      "integrity": "sha512-BomnpmKNIc5zpEKqR9Jye20GzyykIfsQj3iU5fiX4znCaOotoBirssCdwnjP2Qe15LloYsMk+jCI5qLhl2/Jag==",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "assert": "^2.0.0",
-        "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
     "@fluidframework/driver-definitions": {
-      "version": "0.39.4",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.4.tgz",
-      "integrity": "sha512-KWZxNwXnhuR6rzSwExYD8FivG1qFIISdnbuR8KbPTEVYsryl6b2YHnelWVAayy/48h1/lVU1/zNRotmrGxZTVQ==",
+      "version": "0.39.6",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-definitions/-/driver-definitions-0.39.6.tgz",
+      "integrity": "sha512-R+Bfnv0CWruzKu43wMhT6voF61kmpoDE2bLY4MZNB01Mgevvj50uCY42m3rQ36nEcu1+iEvP5/jDCxgMwtDEuw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.0",
-        "@fluidframework/core-interfaces": "^0.39.4",
+        "@fluidframework/core-interfaces": "^0.39.6",
         "@fluidframework/protocol-definitions": "^0.1024.0"
       }
     },
     "@fluidframework/driver-utils": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.41.0.tgz",
-      "integrity": "sha512-2eRlirHro5kkJKVnexjcR0Ms7/oUZmJa7I/poDGz4CVp+Nze0V6nBQM73nYGvQGFqvs94x3ANxaHh7BIj0cFIQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/driver-utils/-/driver-utils-0.43.0.tgz",
+      "integrity": "sha512-bHJ9BXDSrgEcOI2m7FtN3tbwRUzQkEUdY0MysvnbuHn0fHYqAg7MIFjCALyXRJx6nMhUa39Esf4F1INNT5mEsQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/gitresources": "^0.1027.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/garbage-collector": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.41.0.tgz",
-      "integrity": "sha512-ZA76FL0QP+yd/NseYPtVeNvypfrDoNzV5KpZEamADW5f6wj6YR/q/xPYfA19rfxlrW75KHQZKKW6Wij+ZbeepQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/garbage-collector/-/garbage-collector-0.43.0.tgz",
+      "integrity": "sha512-ACytvxe8MTG/ZWwifYLccn+7fnk1L7OOKro8LX/N9ZF+tsUf0SeWsPHTEp5Q0DhEhYZQLqCSNX17sqS4WGyaXQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/runtime-definitions": "^0.41.0"
+        "@fluidframework/runtime-definitions": "^0.43.0"
       }
     },
     "@fluidframework/gitresources": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1026.0.tgz",
-      "integrity": "sha512-a479eaZ9fYm8SI3S5iFwfY1Mk3rOChHLnyY4BkucNKm1RMF30htMA2A53ME/pCZRmLHD39uWr6yPYcvL8egmnQ=="
-    },
-    "@fluidframework/local-driver": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/local-driver/-/local-driver-0.41.0.tgz",
-      "integrity": "sha512-ryDs3GW3FWh8yCxDF9xv2XmD9qww2WxCFcUVqpxfHbBBB4PEV6Yt92BteIyfrUcdz4bl4fwpUURRz9nDIPONBg==",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/driver-base": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/routerlicious-driver": "^0.41.0",
-        "@fluidframework/server-local-server": "^0.1026.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/server-services-core": "^0.1026.0",
-        "@fluidframework/server-test-utils": "^0.1026.0",
-        "assert": "^2.0.0",
-        "debug": "^4.1.1",
-        "jsrsasign": "^10.2.0",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
+      "version": "0.1027.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/gitresources/-/gitresources-0.1027.0.tgz",
+      "integrity": "sha512-nFgew2ojQIgmhX5rP532VOC0hex3ffAk2eOcl5Eo4CBMqWutjyVem2hpcdnCGa54jDI/cVyOsvLrCvBhDX0WEw=="
     },
     "@fluidframework/map": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.41.0.tgz",
-      "integrity": "sha512-u6RpGskMf5RUEvdvF0eQu5MV5j9zJfQpnEXq1P7ssalyG/tLVKyduRebqjCs8q/u0gUlCwQ0U01P6uu4cB5Otg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/map/-/map-0.43.0.tgz",
+      "integrity": "sha512-CQXDPMiT3JgbUpcS1T8zmfPR20+5I4oJA6YqlOEfdFQPY/S5dn9XBQGJRI9wHZNprMu5gkLhMAkE+PaCXcJUpQ==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore-definitions": "^0.43.0",
+        "@fluidframework/driver-utils": "^0.43.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/shared-object-base": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/shared-object-base": "^0.43.0",
         "debug": "^4.1.1",
         "path-browserify": "^1.0.1"
       },
       "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
         "path-browserify": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
           "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
         }
       }
     },
     "@fluidframework/merge-tree": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.41.0.tgz",
-      "integrity": "sha512-jcknmNPlCikpAoZsx3i//g3N998unVhWAfZlP0ea0tz+Q4J+oa8mExq0yH2bjxu/bHXdTr0VfjI/drn2nMKlhQ==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/merge-tree/-/merge-tree-0.43.0.tgz",
+      "integrity": "sha512-oTj8XyCfT2UCaEqESvu+2dLwVIeK7TBhs2PxdbC+XRbBWaqclw0P5H9xM3neDUZ55D7X+eeUq/HGcDIJwkZdvA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
+        "@fluidframework/telemetry-utils": "^0.43.0"
       }
     },
     "@fluidframework/protocol-base": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1026.0.tgz",
-      "integrity": "sha512-8J4OGuRjDurKCZDKXEW8KLbZDVHtrlMn1X+vShSKVQCzb5YvfQ0mhZihsAZNW4FERj9EbjtkefW9wJgnra8xWw==",
+      "version": "0.1027.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/protocol-base/-/protocol-base-0.1027.0.tgz",
+      "integrity": "sha512-JZGHpGL9+PZn9L6z+wUdiS9z0PcR/vusd1Tz6Ei5FN/6U4WdInpFtlcBcjGq0tjYzOym1ouipNu8HPPCxTI9IA==",
       "requires": {
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/gitresources": "^0.1026.0",
+        "@fluidframework/gitresources": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
         "assert": "^2.0.0",
         "lodash": "^4.17.21"
@@ -2192,318 +1906,76 @@
         "@fluidframework/common-definitions": "^0.20.0"
       }
     },
-    "@fluidframework/register-collection": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/register-collection/-/register-collection-0.41.0.tgz",
-      "integrity": "sha512-wTDi3g5ocF5M0wyIjto8uQsbSriXTXRsT7DnIt0XSqx/5wHtge/3FAqUWQgrmBmK3YfboDhH1FqyiKgZco0hKQ==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/shared-object-base": "^0.41.0",
-        "assert": "^2.0.0",
-        "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
     "@fluidframework/request-handler": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.41.0.tgz",
-      "integrity": "sha512-c7w7YHRAoMHYsrOOxxi00RzXV6awyqxk/d0ABCY5/v9hYpm03BEdvEQKQLuoKUgcBF2bSALc0y4QK/xRIn2lbA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/request-handler/-/request-handler-0.43.0.tgz",
+      "integrity": "sha512-8qz1KGokTSX/baqB5cAD46WAvV5zRuOZ1I6f6gjPtrN/z6gPtRr+O5pGoq4JBYpVDZJGEf8hxw3oalC7OrZWzA==",
       "requires": {
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-runtime-definitions": "^0.41.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "assert": "^2.0.0"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
-    "@fluidframework/routerlicious-driver": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/routerlicious-driver/-/routerlicious-driver-0.41.0.tgz",
-      "integrity": "sha512-Jz+bm9tBbdCw6iEfbsoNd6HSjCtG+LNX+8uQbJFbrcVimaBoxzVk7UPkViFhbws5cJ9V7MG9iafSDuWw1jzAIA==",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/driver-base": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
-        "axios": "^0.21.1",
-        "debug": "^4.1.1",
-        "json-stringify-safe": "5.0.1",
-        "socket.io-client": "^2.1.1",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
+        "@fluidframework/container-runtime-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0"
       }
     },
     "@fluidframework/runtime-definitions": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.41.0.tgz",
-      "integrity": "sha512-vfYDgfnhsyZe7yU1Ws8XhEQBWhRZaodQ04DzyRP6nfgjyd72qNKQ+a5unhMZun4CFxDiyneNm0Bl2WnQ64R9KA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-definitions/-/runtime-definitions-0.43.0.tgz",
+      "integrity": "sha512-XQ2xDqgquv79wlNNBpwEYh8+BMbiRYEOmdZRvJNmcvHaewCv6vciuu5qo8LI0O0KzJgYEWM8QOWMOOjCVPWbfg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.39.5",
         "@fluidframework/driver-definitions": "^0.39.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
         "@types/node": "^12.19.0"
       }
     },
     "@fluidframework/runtime-utils": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.41.0.tgz",
-      "integrity": "sha512-DeWFbmFPwXMbQTs8Rg+rd06KUN6mbBF4PZA4/mmGQ4FsZEbkD0nBXAP3xd6s7ZlXKjHmZ2JujscXxPydB42YaA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/runtime-utils/-/runtime-utils-0.43.0.tgz",
+      "integrity": "sha512-WEjH66gynHNJtzT7CsWdvfZTKOabynZyFJ0MlAvNfy1xTpiO4qNsOK2JWhchljH5xGI82O8mPggzpKLaRHN0eA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/garbage-collector": "^0.41.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/container-runtime-definitions": "^0.43.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore-definitions": "^0.43.0",
+        "@fluidframework/garbage-collector": "^0.43.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "assert": "^2.0.0"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
+        "@fluidframework/runtime-definitions": "^0.43.0"
       }
     },
     "@fluidframework/sequence": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.41.0.tgz",
-      "integrity": "sha512-Pad6TWBF26j83NXi1W8wlubdA3Jqu1pEBs8pODrH1MrJeEGhp2aysJJDaXJaouhIhJIDOfw5qMTDoYhQ6MNHlA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/sequence/-/sequence-0.43.0.tgz",
+      "integrity": "sha512-PznNGDJhOr/++oZrgPPw1Dba3LPkPXJcrrC0MNJbbfwGdm3vm+aR6lvGj1XBNBvzFw50BLfwX1mQQ5q9XPevKw==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/merge-tree": "^0.41.0",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore-definitions": "^0.43.0",
+        "@fluidframework/merge-tree": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/shared-object-base": "^0.41.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
-        "debug": "^4.1.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
-    "@fluidframework/server-lambdas": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-lambdas/-/server-lambdas-0.1026.0.tgz",
-      "integrity": "sha512-fbPbKfCrnkW3C/X0+ctIL+t1VLI8GwpwJT0UCwtkNJ/S8SKGdEU3BfN4hgBBi2Bb3yrB7v1H6aujNdigAQ6OnA==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/server-services-core": "^0.1026.0",
-        "@types/semver": "^6.0.1",
-        "async": "^3.2.0",
-        "double-ended-queue": "^2.1.0-0",
-        "json-stringify-safe": "^5.0.1",
-        "jsonwebtoken": "^8.4.0",
-        "lodash": "^4.17.21",
-        "nconf": "^0.11.0",
-        "semver": "^6.3.0",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        }
-      }
-    },
-    "@fluidframework/server-local-server": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-local-server/-/server-local-server-0.1026.0.tgz",
-      "integrity": "sha512-iZZ66t2egyr0ihDe3tS0HvixwAGCJ4JGOd5fb7f1+0WfOMsMJ4caKyz/wERvNNlsYE+P60ro7dh8RASNACJlkA==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-lambdas": "^0.1026.0",
-        "@fluidframework/server-memory-orderer": "^0.1026.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/server-services-core": "^0.1026.0",
-        "@fluidframework/server-test-utils": "^0.1026.0",
-        "jsrsasign": "^10.2.0",
-        "uuid": "^8.3.1"
-      }
-    },
-    "@fluidframework/server-memory-orderer": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-memory-orderer/-/server-memory-orderer-0.1026.0.tgz",
-      "integrity": "sha512-gct2zQLnZWkjS2gVJF3okj9HIlduLoaDWxhQaekhAOLiN3VbHGzKipKY6MqYU0DZSyjU8yUpurLwoQGyQXRUgQ==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-lambdas": "^0.1026.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/server-services-core": "^0.1026.0",
-        "@types/debug": "^4.1.5",
-        "@types/double-ended-queue": "^2.1.0",
-        "@types/lodash": "^4.14.118",
-        "@types/node": "^12.19.0",
-        "@types/ws": "^6.0.1",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/shared-object-base": "^0.43.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "debug": "^4.1.1",
-        "double-ended-queue": "^2.1.0-0",
-        "lodash": "^4.17.21",
-        "moniker": "^0.1.2",
-        "uuid": "^8.3.1",
-        "ws": "^7.4.6"
+        "uuid": "^8.3.1"
       }
     },
     "@fluidframework/server-services-client": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1026.0.tgz",
-      "integrity": "sha512-ZEMiWqh5+FkYQIgZJnIrs/jmkCKIi/7V0VEzI/ZreayP1jYsRJBXqB1UvGpgGMFiwpTY5ooP2bHGn04hsnCC0A==",
+      "version": "0.1027.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-client/-/server-services-client-0.1027.0.tgz",
+      "integrity": "sha512-FQcC3TPhfs/GHtfW/0aqGD5rehwhgCmZcmAWDi+QkKatWzV/Z/SD0uyA7Bk9qRE5jgNNP3ny5XaZ4jETJJ2Zvg==",
       "requires": {
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
+        "@fluidframework/gitresources": "^0.1027.0",
+        "@fluidframework/protocol-base": "^0.1027.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
         "@types/node": "^12.19.0",
         "axios": "^0.21.1",
@@ -2514,96 +1986,37 @@
         "uuid": "^8.3.1"
       }
     },
-    "@fluidframework/server-services-core": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-services-core/-/server-services-core-0.1026.0.tgz",
-      "integrity": "sha512-3fpveTPVQmN6RhZJFtoEjRGLj0lLqvTwB+Lx4cthp76cHFg2nBq6Q94VUbxUN4xU+1v6THN+zJQfI/Kbxb4XiA==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@types/nconf": "^0.10.0",
-        "@types/node": "^12.19.0",
-        "debug": "^4.1.1",
-        "nconf": "^0.11.0"
-      }
-    },
-    "@fluidframework/server-test-utils": {
-      "version": "0.1026.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/server-test-utils/-/server-test-utils-0.1026.0.tgz",
-      "integrity": "sha512-J2MaLYd4MldTpxnJB8QP10SzQGXGBr4Y16oUf5MEqgd9z6nuohwvG5Ma1N7FpStI/oia+5vDaPuELvpFNU6mPA==",
-      "requires": {
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/gitresources": "^0.1026.0",
-        "@fluidframework/protocol-base": "^0.1026.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "@fluidframework/server-services-core": "^0.1026.0",
-        "debug": "^4.1.1",
-        "lodash": "^4.17.21",
-        "string-hash": "^1.1.3",
-        "uuid": "^8.3.1"
-      }
-    },
     "@fluidframework/shared-object-base": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.41.0.tgz",
-      "integrity": "sha512-4U0PLXv0zlaark1L/xfY0Wt0fx4kvWNPL8efRAqVFcPNNutfQ0g1i4+9ZjdwFFNJROHlMiBMmNkM0xdstZjkQw==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/shared-object-base/-/shared-object-base-0.43.0.tgz",
+      "integrity": "sha512-jpHatxVCXEjXQqTwmfSrGOEbfVXuyG/8WDsmm+SRYjHA91KBXMn12cfQGZY48JiNCeYG9P+KPRO5e8HvwTJfAA==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore": "^0.41.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
+        "@fluidframework/container-definitions": "^0.39.5",
+        "@fluidframework/core-interfaces": "^0.39.5",
+        "@fluidframework/datastore": "^0.43.0",
+        "@fluidframework/datastore-definitions": "^0.43.0",
         "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
+        "@fluidframework/runtime-definitions": "^0.43.0",
+        "@fluidframework/runtime-utils": "^0.43.0",
+        "@fluidframework/telemetry-utils": "^0.43.0",
         "debug": "^4.1.1",
         "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
       }
     },
     "@fluidframework/synthesize": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.41.0.tgz",
-      "integrity": "sha512-BVLjrW7LQSi9FxkcCuxYzT5G29Dj3O5cilUuZHmiA9pMCKDY3DS2slm8TNp7FpNYHJ9uFsMFLqriUIVmxz+JVg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/synthesize/-/synthesize-0.43.0.tgz",
+      "integrity": "sha512-814J7OhGfjWOJrvhyrMIo25/jZj7LOuVkdkGucwFuhJwLNtBQGx7DF+rrLfzomLFuo2QKq4MAORUa2XH04DmBA==",
       "requires": {
-        "@fluidframework/core-interfaces": "^0.39.0"
+        "@fluidframework/core-interfaces": "^0.39.5"
       }
     },
     "@fluidframework/telemetry-utils": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.41.0.tgz",
-      "integrity": "sha512-qTrMXjg0EVBI8toDRyrpZ15x82yDg0eS+9jPQHcqeGfONlcVfvl7SdgnKT2gC+UGaBSmBDuP5MmVGw50N3IqDg==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/telemetry-utils/-/telemetry-utils-0.43.0.tgz",
+      "integrity": "sha512-LODZgc1HRxCJnHHjaTm69p0AJjgc4ly4gM/ON6H+OIXDmnWlALkVXkvl7qdCJKtTHPPuF7y5+q+R/msh1oHkbg==",
       "requires": {
         "@fluidframework/common-definitions": "^0.20.1",
         "@fluidframework/common-utils": "^0.31.0",
@@ -2611,76 +2024,12 @@
         "events": "^3.1.0"
       }
     },
-    "@fluidframework/test-runtime-utils": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/test-runtime-utils/-/test-runtime-utils-0.41.0.tgz",
-      "integrity": "sha512-Dv7Zby3PiaKWpapNrhlob0sEWWSA/9kvIgcGcLSL3lpIUYo63w+AoQXbJaq8aICdhIZYsGKL8uMiXws9b/+sKg==",
-      "requires": {
-        "@fluidframework/common-definitions": "^0.20.1",
-        "@fluidframework/common-utils": "^0.31.0",
-        "@fluidframework/container-definitions": "^0.39.0",
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/datastore-definitions": "^0.41.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/routerlicious-driver": "^0.41.0",
-        "@fluidframework/runtime-definitions": "^0.41.0",
-        "@fluidframework/runtime-utils": "^0.41.0",
-        "@fluidframework/telemetry-utils": "^0.41.0",
-        "assert": "^2.0.0",
-        "axios": "^0.21.1",
-        "jsrsasign": "^10.2.0",
-        "uuid": "^8.3.1"
-      },
-      "dependencies": {
-        "assert": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
-          "integrity": "sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==",
-          "requires": {
-            "es6-object-assign": "^1.1.0",
-            "is-nan": "^1.2.1",
-            "object-is": "^1.0.1",
-            "util": "^0.12.0"
-          }
-        },
-        "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
-    "@fluidframework/tinylicious-driver": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/tinylicious-driver/-/tinylicious-driver-0.41.0.tgz",
-      "integrity": "sha512-YXXSdr0rbDdT1sSTuW/OT2FcQ3qmQCbdH/JGzuOeYelG47x3+c/G92fhCVErwoAb16ZCciamQquXNJ9UIgbDgg==",
-      "requires": {
-        "@fluidframework/core-interfaces": "^0.39.0",
-        "@fluidframework/driver-definitions": "^0.39.0",
-        "@fluidframework/driver-utils": "^0.41.0",
-        "@fluidframework/protocol-definitions": "^0.1024.0",
-        "@fluidframework/routerlicious-driver": "^0.41.0",
-        "@fluidframework/server-services-client": "^0.1026.0",
-        "jsrsasign": "^10.2.0",
-        "uuid": "^8.3.1"
-      }
-    },
     "@fluidframework/view-interfaces": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.41.0.tgz",
-      "integrity": "sha512-uySndyQIbNO8UDfybq9zydt5tTZTpZHy5j/nkcGpKyXHoxlGzhKbzZbWSPjKLzEIzzQHjogo+eYYGbKCG1Vq6g==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@fluidframework/view-interfaces/-/view-interfaces-0.43.0.tgz",
+      "integrity": "sha512-41ma3Os1heRF29dB/YBYuNF1WKLeQ5aAtjogWv1kkSR7ehLzvPaALsNB32zPjnd2IPIlLPvETAw2Pr5Flz9JPw==",
       "requires": {
-        "@fluidframework/core-interfaces": "^0.39.0"
+        "@fluidframework/core-interfaces": "^0.39.5"
       }
     },
     "@hapi/address": {
@@ -3709,16 +3058,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/debug": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
-      "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ=="
-    },
-    "@types/double-ended-queue": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@types/double-ended-queue/-/double-ended-queue-2.1.1.tgz",
-      "integrity": "sha512-O2+umEIlHBVyi+ePmucPjpINqTvSnsz+hAok0D4IpvrOsIsDr6c34B0AbNXW2UDVYuxbv51z5dxnrRt23ohgWg=="
-    },
     "@types/eslint": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.13.tgz",
@@ -3806,20 +3145,10 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
-    "@types/lodash": {
-      "version": "4.14.170",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.170.tgz",
-      "integrity": "sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q=="
-    },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
-    },
-    "@types/nconf": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@types/nconf/-/nconf-0.10.0.tgz",
-      "integrity": "sha512-Qh0/DWkz7fQm5h+IPFBIO5ixaFdv86V6gpbA8TPA1hhgXYtzGviv9yriqN1B+KTtmLweemKZD5XxY1cTAQPNMg=="
     },
     "@types/node": {
       "version": "12.20.14",
@@ -3903,11 +3232,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.1.tgz",
       "integrity": "sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA=="
     },
-    "@types/semver": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-6.2.2.tgz",
-      "integrity": "sha512-RxAwYt4rGwK5GyoRwuP0jT6ZHAVTdz2EqgsHmX0PYNjGsko+OeT4WFXXTs/lM3teJUJodM+SNtAL5/pXIJ61IQ=="
-    },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
@@ -3986,14 +3310,6 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
         }
-      }
-    },
-    "@types/ws": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
-      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
-      "requires": {
-        "@types/node": "*"
       }
     },
     "@types/yargs": {
@@ -5426,11 +4742,6 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
-    },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -6869,14 +6180,6 @@
         }
       }
     },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -7041,6 +6344,59 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dev": true,
+      "requires": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "errno": {
       "version": "0.1.8",
@@ -11402,30 +10758,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
-      }
-    },
     "jsrsasign": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-10.3.0.tgz",
@@ -11438,25 +10770,6 @@
       "requires": {
         "array-includes": "^3.1.2",
         "object.assign": "^4.1.2"
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "jwt-decode": {
@@ -11595,36 +10908,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -11634,11 +10917,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.template": {
       "version": "4.5.0",
@@ -12042,11 +11320,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "moniker": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
-      "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4="
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -12130,94 +11403,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
-    },
-    "nconf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.2.tgz",
-      "integrity": "sha512-gDmn0Fgt0U0esRE8OCF72tO8AA9dtlG9eZhW4/Ex5hozNC2/LgdhWO4vKLGHNfTxcvsv6Aoxk/ROVYJD2SAdyg==",
-      "requires": {
-        "async": "^1.4.0",
-        "ini": "^2.0.0",
-        "secure-keys": "^1.0.0",
-        "yargs": "^16.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "ini": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-          "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
-        },
-        "wrap-ansi": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.7",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
-          "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
-        }
-      }
     },
     "negotiator": {
       "version": "0.6.2",
@@ -15340,11 +14525,6 @@
         "ajv-keywords": "^3.5.2"
       }
     },
-    "secure-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-      "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
-    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -16105,11 +15285,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "dependencies": {
     "@fluentui/react": "^8.17.1",
-    "@fluid-experimental/fluid-framework": "^0.41.0",
-    "@fluid-experimental/tinylicious-client": "^0.41.0",
+    "@fluid-experimental/fluid-framework": "^0.43.0",
+    "@fluid-experimental/frs-client": "^0.43.0",
+    "@fluidframework/server-services-client": "^0.1027.0",
     "@testing-library/jest-dom": "^5.13.0",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -24,6 +25,7 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:frs": "env-cmd -f .env.frs react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -47,6 +49,7 @@
     ]
   },
   "devDependencies": {
-    "@types/react-router-dom": "^5.1.7"
+    "@types/react-router-dom": "^5.1.7",
+    "env-cmd": "10.1.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
+import { SharedMap } from "@fluid-experimental/fluid-framework";
 import {
-  SharedMap,
-} from "@fluid-experimental/fluid-framework";
+  FrsConnectionConfig,
+  InsecureTokenProvider,
+} from "@fluid-experimental/frs-client";
+import { generateUser } from "@fluidframework/server-services-client";
 
 export const containerConfig = {
   name: "cra-demo-container",
@@ -9,7 +12,7 @@ export const containerConfig = {
   },
 };
 
-export const FILEPATH  = 'fluid';
+export const FILEPATH = "fluid";
 
 export const serviceConfig = {};
 
@@ -21,5 +24,26 @@ export const defaultData: any[] = [
   {
     id: "2",
     value: 2,
-  }
+  },
 ];
+
+export const useFrs: boolean = process.env.REACT_APP_USE_FRS !== undefined;
+
+export const user = generateUser();
+
+export const connectionConfig: FrsConnectionConfig = useFrs
+  ? {
+      tenantId: "",
+      tokenProvider: new InsecureTokenProvider(
+        "",
+        user
+      ),
+      orderer: "",
+      storage: "",
+    }
+  : {
+      tenantId: "local",
+      tokenProvider: new InsecureTokenProvider("fooBar", user),
+      orderer: "http://localhost:7070",
+      storage: "http://localhost:7070",
+    };

--- a/src/model/model.ts
+++ b/src/model/model.ts
@@ -1,14 +1,11 @@
-import { ISharedMap } from "@fluid-experimental/fluid-framework";
+import { ISharedMap, FluidContainer } from "@fluid-experimental/fluid-framework";
 import { EventEmitter } from "events";
-import {
-  TinyliciousContainerServices,
-} from "@fluid-experimental/tinylicious-client";
-import { FluidContainer } from "@fluid-experimental/fluid-static";
+import { FrsContainerServices } from "@fluid-experimental/frs-client";
 import { Node } from "./types";
 
 export class FluidModel extends EventEmitter {
   private map: ISharedMap;
-  constructor(private container: FluidContainer, private services: TinyliciousContainerServices) {
+  constructor(private container: FluidContainer, private services: FrsContainerServices) {
     super();
     this.map = container.initialObjects.myMap as ISharedMap;
     this.map.on("valueChanged", (changed, local, op, target) => {

--- a/src/utils/containerUtils.ts
+++ b/src/utils/containerUtils.ts
@@ -1,9 +1,15 @@
 import { ISharedMap } from "@fluid-experimental/fluid-framework";
+import { FrsClient } from "@fluid-experimental/frs-client";
+import { v4 as uuid } from "uuid";
 import {
-  TinyliciousClient,
-} from "@fluid-experimental/tinylicious-client";
-import { v4 as uuid } from 'uuid';
-import { containerConfig, defaultData, serviceConfig, FILEPATH } from "../config";
+  containerConfig,
+  defaultData,
+  serviceConfig,
+  FILEPATH,
+  connectionConfig,
+} from "../config";
+
+const client = new FrsClient(connectionConfig);
 
 export const createFilePath = (id: string) => {
   return `/${FILEPATH}/${id}`;
@@ -11,14 +17,17 @@ export const createFilePath = (id: string) => {
 
 export const createFluidFile = async () => {
   const id = uuid();
-  const fluidContainer = (await TinyliciousClient.createContainer({ ...serviceConfig, id }, containerConfig))[0];
+  const { fluidContainer } = await client.createContainer(
+    { ...serviceConfig, id },
+    containerConfig
+  );
   const map = fluidContainer.initialObjects.myMap as ISharedMap;
   for (const data of defaultData) {
-    map.set(data.id, {value:data.value})
+    map.set(data.id, { value: data.value });
   }
   return createFilePath(id);
 }
 
 export const getFluidContainer = async (id: string) => {
-  return await TinyliciousClient.getContainer({ ...serviceConfig, id }, containerConfig);
+  return await client.getContainer({ ...serviceConfig, id }, containerConfig);
 }

--- a/src/utils/context/FluidContext.tsx
+++ b/src/utils/context/FluidContext.tsx
@@ -8,8 +8,8 @@ export const FluidContext: React.FC<{ id: string }> = ({id, children}) => {
 
   useEffect(() => {
     const loadModel = async () => {
-      const [container, services] = await getFluidContainer(id);
-      setModel(new FluidModel(container, services))
+      const { fluidContainer, containerServices } = await getFluidContainer(id);
+      setModel(new FluidModel(fluidContainer, containerServices))
     }
     loadModel();
   }, [id]);

--- a/src/view/App.tsx
+++ b/src/view/App.tsx
@@ -1,10 +1,7 @@
 import React from "react";
-import TLC from "@fluid-experimental/tinylicious-client";
 import { FluidPage, Home } from "./pages";
 import { FILEPATH } from "../config";
 import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
-
-TLC.init();
 
 const App = () => {
   return (


### PR DESCRIPTION
- Replaces TinyliciousClient with FrsClient that takes in two different configs, one for connecting to local Tinylicious instance and another for connecting to live FRS instance
- Adds environment variable toggle for when to use Tinylicious vs FRS. This is used by running `npm run start` for local Tinylicious config and `npm run start:frs` for using the remote FRS config
- Updates FF dependencies to 0.43